### PR TITLE
Code fixes

### DIFF
--- a/src/Mos.xApi/Actors/AgentBuilder.cs
+++ b/src/Mos.xApi/Actors/AgentBuilder.cs
@@ -11,7 +11,7 @@ namespace Mos.xApi.Actors
         /// <summary>
         /// The full name of the Agent.
         /// </summary>
-        private string _name;
+        private readonly string _name;
 
         /// <summary>
         /// Initializes a new instance of an Agent class.

--- a/src/Mos.xApi/Actors/Group.cs
+++ b/src/Mos.xApi/Actors/Group.cs
@@ -12,7 +12,7 @@ namespace Mos.xApi.Actors
     public class Group : Actor
     {
         /// <summary>
-        /// Initializes a new intance of <see cref="Group"/>. This constructor call creates an anonymous group.
+        /// Initializes a new instance of <see cref="Group"/>. This constructor call creates an anonymous group.
         /// <para>An Anonymous Group is used describe a cluster of people where there is no ready identifier for this cluster, e.g. an ad hoc team.</para>
         /// </summary>
         /// <param name="members">The members of this Group. This is an unordered list.</param>
@@ -26,7 +26,7 @@ namespace Mos.xApi.Actors
         }
 
         /// <summary>
-        /// Initializes a new intance of <see cref="Group"/>. This constructor call creates an identified group.
+        /// Initializes a new instance of <see cref="Group"/>. This constructor call creates an identified group.
         /// <para>An Identified Group is used to uniquely identify a cluster of Agents.</para>
         /// </summary>
         /// <param name="identifier">An Inverse Functional Identifier unique to the Group.</param>

--- a/src/Mos.xApi/Builders/ContextBuilder.cs
+++ b/src/Mos.xApi/Builders/ContextBuilder.cs
@@ -14,17 +14,17 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// List of activities that are used to categorize a Statement
         /// </summary>
-        private List<Activity> _categories;
+        private readonly List<Activity> _categories;
 
         /// <summary>
         /// The list of extensions available to the Context
         /// </summary>
-        private Extension _extensions;
+        private readonly Extension _extensions;
 
         /// <summary>
         /// A list of activities with an indirect relation to the Activity which is the Object of the Statement.
         /// </summary>
-        private List<Activity> _groupings;
+        private readonly List<Activity> _groupings;
 
         /// <summary>
         /// Instructor that the Statement relates to, if not included as the Actor of the Statement.
@@ -39,12 +39,12 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// A list of context Activities that doesn't fit one of the other properties
         /// </summary>
-        private List<Activity> _others;
+        private readonly List<Activity> _others;
 
         /// <summary>
         /// A list of activities with a direct relation to the Activity which is the Object of the Statement.
         /// </summary>
-        private List<Activity> _parents;
+        private readonly List<Activity> _parents;
 
         /// <summary>
         /// Platform used in the experience of this learning activity.
@@ -316,7 +316,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// Sets the platform used in the experience of this learning activity.
         /// </summary>
-        /// <param name="platform">The plateform used in the experience of this learning activity.</param>
+        /// <param name="platform">The platform used in the experience of this learning activity.</param>
         /// <returns>The builder class, for the fluent API.</returns>
         public IContextBuilder WithPlatform(string platform)
         {

--- a/src/Mos.xApi/Builders/IContextBuilder.cs
+++ b/src/Mos.xApi/Builders/IContextBuilder.cs
@@ -138,7 +138,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// Sets the platform used in the experience of this learning activity.
         /// </summary>
-        /// <param name="platform">The plateform used in the experience of this learning activity.</param>
+        /// <param name="platform">The platform used in the experience of this learning activity.</param>
         /// <returns>The builder class, for the fluent API.</returns>
         IContextBuilder WithPlatform(string platform);
 

--- a/src/Mos.xApi/Builders/ResultBuilder.cs
+++ b/src/Mos.xApi/Builders/ResultBuilder.cs
@@ -20,7 +20,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// A map of other properties as needed.
         /// </summary>
-        private Extension _extensions;
+        private readonly Extension _extensions;
 
         /// <summary>
         /// A response appropriately formatted for the given Activity.

--- a/src/Mos.xApi/Builders/StatementBuilder.cs
+++ b/src/Mos.xApi/Builders/StatementBuilder.cs
@@ -25,7 +25,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// Whom the Statement is about, as an Agent or Group Object.
         /// </summary>
-        private Actor _actor;
+        private readonly Actor _actor;
 
         /// <summary>
         /// Agent or Group who is asserting this Statement is true. 
@@ -45,7 +45,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// Activity, Agent, or another Statement that is the Object of the Statement.
         /// </summary>
-        private StatementObject _statementObject;
+        private readonly StatementObject _statementObject;
 
         /// <summary>
         /// Timestamp of when the events described within this Statement occurred.
@@ -55,7 +55,7 @@ namespace Mos.xApi.Builders
         /// <summary>
         /// Action taken by the Actor.
         /// </summary>
-        private Verb _verb;
+        private readonly Verb _verb;
 
         /// <summary>
         /// Initializes a new instance of a StatementBuilder class.

--- a/src/Mos.xApi/Client/ILrsClient.cs
+++ b/src/Mos.xApi/Client/ILrsClient.cs
@@ -19,7 +19,7 @@ namespace Mos.xApi.Client
         Task<StatementResult> FindMoreStatementsAsync(Uri moreStatementsUri);
 
         /// <summary>
-        /// Fetches all the statements corresponsing to the specified query.
+        /// Fetches all the statements corresponding to the specified query.
         /// </summary>
         /// <param name="query">The query defining the statements to retrieve</param>
         /// <returns>The list of all statements corresponding to the query.</returns>

--- a/src/Mos.xApi/Client/LrsClient.cs
+++ b/src/Mos.xApi/Client/LrsClient.cs
@@ -20,7 +20,7 @@ namespace Mos.xApi.Client
     public class LrsClient : ILrsClient
     {
         /// <summary>
-        /// Singleton instanciated HttpClient
+        /// Singleton instantiated HttpClient
         /// </summary>
         private readonly HttpClient HttpClient;
 
@@ -37,7 +37,7 @@ namespace Mos.xApi.Client
         /// <param name="xApiVersion">The version of xApi used.</param>
         public LrsClient(Uri lrsBaseUrl, string statementEndPoint = "statements", string xApiVersion = "1.0.0")
         {
-            HttpClient = new HttpClient()
+            HttpClient = new HttpClient
             {
                 BaseAddress = lrsBaseUrl
             };
@@ -127,7 +127,7 @@ namespace Mos.xApi.Client
         }
 
         /// <summary>
-        /// Fetches all the statements corresponsing to the specified query.
+        /// Fetches all the statements corresponding to the specified query.
         /// </summary>
         /// <param name="query">The query defining the statements to retrieve</param>
         /// <returns>The list of all statements corresponding to the query.</returns>

--- a/src/Mos.xApi/Client/StatementResult.cs
+++ b/src/Mos.xApi/Client/StatementResult.cs
@@ -12,7 +12,7 @@ namespace Mos.xApi.Client
         /// <summary>
         /// The list of statements returned from the query.
         /// </summary>
-        private List<Statement> _statements;
+        private readonly List<Statement> _statements;
 
         /// <summary>
         /// Initializes a new instance of a StatementResult class.

--- a/src/Mos.xApi/Extension.cs
+++ b/src/Mos.xApi/Extension.cs
@@ -31,7 +31,7 @@ namespace Mos.xApi
         }
 
         /// <summary>
-        /// Initializes a new instance of the Extension disctionary which is empty.
+        /// Initializes a new instance of the Extension dictionary which is empty.
         /// </summary>
         public Extension() { }
     }

--- a/src/Mos.xApi/InverseFunctionalIdentifiers/Account.cs
+++ b/src/Mos.xApi/InverseFunctionalIdentifiers/Account.cs
@@ -39,7 +39,7 @@ namespace Mos.xApi.InverseFunctionalIdentifiers
 
             if (!homePage.IsWellFormedOriginalString())
             {
-                throw new ArgumentException($"Homepage uri is malformed: {homePage.ToString()}", nameof(homePage));
+                throw new ArgumentException($"Homepage uri is malformed: {homePage}", nameof(homePage));
             }
 
             Name = name;

--- a/src/Mos.xApi/LanguageMap.cs
+++ b/src/Mos.xApi/LanguageMap.cs
@@ -9,7 +9,7 @@ namespace Mos.xApi
     public class LanguageMap : Dictionary<string, string>, ILanguageMap
     {
         /// <summary>
-        /// Initializes a new instance of the LanguageMap disctionary which is empty.
+        /// Initializes a new instance of the LanguageMap dictionary which is empty.
         /// </summary>
         public LanguageMap() { }
 

--- a/src/Mos.xApi/Objects/ActivityBuilder.cs
+++ b/src/Mos.xApi/Objects/ActivityBuilder.cs
@@ -24,12 +24,12 @@ namespace Mos.xApi.Objects
         /// <summary>
         /// A description of the Activity
         /// </summary>
-        private LanguageMap _descriptionLanguageMap;
+        private readonly LanguageMap _descriptionLanguageMap;
 
         /// <summary>
         /// A map of other properties as needed
         /// </summary>
-        private Extension _extensions;
+        private readonly Extension _extensions;
 
         /// <summary>
         /// Resolves to a document with human-readable information about the Activity, which could include a way to launch the activity.
@@ -39,7 +39,7 @@ namespace Mos.xApi.Objects
         /// <summary>
         /// The human readable/visual name of the Activity
         /// </summary>
-        private LanguageMap _nameLanguageMap;
+        private readonly LanguageMap _nameLanguageMap;
 
         /// <summary>
         /// Initializes a new instance of the ActivityBuilder class.

--- a/src/Mos.xApi/Objects/InteractionActivities/ChoiceInteractionActivity.cs
+++ b/src/Mos.xApi/Objects/InteractionActivities/ChoiceInteractionActivity.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace Mos.xApi.Objects.InteractionActivities
 {

--- a/src/Mos.xApi/Objects/SubStatementBuilder.cs
+++ b/src/Mos.xApi/Objects/SubStatementBuilder.cs
@@ -13,7 +13,7 @@ namespace Mos.xApi.Objects
         /// <summary>
         /// Whom the SubStatement is about, as an Agent or Group Object.
         /// </summary>
-        private Actor _actor;
+        private readonly Actor _actor;
 
         /// <summary>
         /// Headers for Attachments to the SubStatement
@@ -33,7 +33,7 @@ namespace Mos.xApi.Objects
         /// <summary>
         /// Activity or Agent that is the Object of the SubStatement.
         /// </summary>
-        private StatementObject _statementObject;
+        private readonly StatementObject _statementObject;
 
         /// <summary>
         /// Timestamp of when the events described within this SubStatement occurred. Set by the LRS if not provided.
@@ -43,7 +43,7 @@ namespace Mos.xApi.Objects
         /// <summary>
         /// Action taken by the Actor.
         /// </summary>
-        private Verb _verb;
+        private readonly Verb _verb;
 
         /// <summary>
         /// Initializes a new instance of the SubStatementBuilder class, passing the

--- a/src/Mos.xApi/Utilities/ActorJsonConverter.cs
+++ b/src/Mos.xApi/Utilities/ActorJsonConverter.cs
@@ -54,7 +54,7 @@ namespace Mos.xApi.Utilities
                 return ParseGroup(item);
             }
 
-            throw new InvalidOperationException($"Cannot parse Actor, unrecognized objectType.\r\n{item.ToString()}");
+            throw new InvalidOperationException($"Cannot parse Actor, unrecognized objectType.\r\n{item}");
         }
 
         /// <summary>
@@ -67,8 +67,14 @@ namespace Mos.xApi.Utilities
             var builder = Actor.CreateAgent(item["name"]?.Value<string>());
             if (item["mbox"] != null)
             {
-                // First 7 characters are the "mailto:", no need to keep it
-                return builder.WithMailBox(item["mbox"].Value<string>().Remove(0, 7));
+                var value = item["mbox"].Value<string>();
+                if (!value.StartsWith(EmailJsonConverter.MailToPrefix))
+                {
+                    throw new NotSupportedException($"mbox value must start with '{EmailJsonConverter.MailToPrefix}' prefix.");
+                }
+
+                var email = value.Substring(EmailJsonConverter.MailToPrefix.Length);
+                return builder.WithMailBox(email);
             }
 
             if (item["openid"] != null)

--- a/src/Mos.xApi/Utilities/EmailJsonConverter.cs
+++ b/src/Mos.xApi/Utilities/EmailJsonConverter.cs
@@ -11,6 +11,8 @@ namespace Mos.xApi.Utilities
     /// </summary>
     internal class EmailJsonConverter : JsonConverter
     {
+        internal const string MailToPrefix = "mailto:";
+
         /// <summary>
         /// Checks whether the type can be converted by this converter. Type should be a string.
         /// </summary>
@@ -56,7 +58,7 @@ namespace Mos.xApi.Utilities
                 throw new NotSupportedException($"{rawValue} is not a valid e-mail address.");
             }
 
-            writer.WriteValue($"mailto:{rawValue}");
+            writer.WriteValue($"{MailToPrefix}{rawValue}");
         }
     }
 }

--- a/src/Mos.xApi/Utilities/LanguageMapConverter.cs
+++ b/src/Mos.xApi/Utilities/LanguageMapConverter.cs
@@ -38,7 +38,7 @@ namespace Mos.xApi.Utilities
         /// from this.
         /// </summary>
         /// <param name="reader">The JsonReader to read from.</param>
-        /// <param name="objectType">Type of the object.</param>
+        /// <parae="objectType">Type of the object.</param>
         /// <param name="existingValue">The existing value of object being read.</param>
         /// <param name="serializer">The calling serializer.</param>
         /// <returns>The object value.</returns>

--- a/src/Mos.xApi/Verb.cs
+++ b/src/Mos.xApi/Verb.cs
@@ -41,7 +41,7 @@ namespace Mos.xApi
         /// <summary>
         /// Initializes a new instance of the <see cref="Verb"/> class with an IRI as an identifier and display information.
         /// </summary>
-        /// <remarks>While not mandatory, it should be prefered to pass the display.</remarks>
+        /// <remarks>While not mandatory, it should be preferred to pass the display.</remarks>
         /// <param name="id">IRI that corresponds to a Verb definition.</param>
         public Verb(Uri id) : this(id, null) { }
 


### PR DESCRIPTION
- Bugfix: when "mailto:" prefix is missing, a partial email address is used
- Made private fields readonly where possible
- Spelling errors in comments
- Unused using
- Unneeded .Totring() calls