### PR TITLE
Enabled SourceLink and replaced depricated PackageLicenseUrl element

### DIFF
--- a/src/Mos.xApi/Mos.xApi.csproj
+++ b/src/Mos.xApi/Mos.xApi.csproj
@@ -4,25 +4,27 @@
     <Description>A fluent .Net Standard library to create xApi statements and communicate with a LRS</Description>
     <Copyright>Copyright © Mos MindOnSite</Copyright>
     <AssemblyTitle>Fluent xApi</AssemblyTitle>
-    <VersionPrefix>0.7.0</VersionPrefix>
     <Authors>Xavier Hahn</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Mos.xApi</AssemblyName>
     <PackageId>Mos.xApi</PackageId>
     <PackageTags>xApi;LRS;e-learning;elearning</PackageTags>
     <PackageProjectUrl>https://github.com/MindOnSite/FluentxApi/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/MindOnSite/FluentxApi/blob/master/LICENSE.txt</PackageLicenseUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/MindOnSite/FluentxApi.git</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <FileVersion>0.7.0.0</FileVersion>
     <Version>0.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.6.0" />


### PR DESCRIPTION
SourceLink enables package consumers to debug into package sources. See https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink for details.

Note that you need to upload the .snupkg file to NuGet too (not sure if AppVeyor supports this already).

Also removed the additional version elements, because their values are copied from `Version` if omitted. Alternatively, you may want to consider freezing `AssemblyVersion` (see https://codingforsmarties.wordpress.com/2016/01/21/how-to-version-assemblies-destined-for-nuget/).